### PR TITLE
Misleading comment in bcrypt

### DIFF
--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -220,8 +220,8 @@ func expensiveBlowfishSetup(key []byte, cost uint32, salt []byte) (*blowfish.Cip
 		return nil, err
 	}
 
-	// Bug compatibility with C bcrypt implementations. They use the trailing
-	// NULL in the key string during expansion.
+	// Append a NULL delimiter because blowfish keys are repeated to fill a 72
+	// byte buffer. This prevents "password" == "passwordpassword".
 	// We copy the key to prevent changing the underlying array.
 	ckey := append(key[:len(key):len(key)], 0)
 


### PR DESCRIPTION
From the comment I thought this was adding in this bug:
```
bcrypt(md5("168", true))            == bcrypt(md5("363", true))
bcrypt(hash('sha256', "286", true)) == bcrypt(hash('sha256', "671", true))
```
Which will work in PHP because the first byte of the password is the null character and PHP uses the "official" C code which does strlen(password) which is zero.

This is not "bug compatibility" it's a bug fix in bcrypt version `$2$` which didn't include a delimiter character and "password" == "passwordpassword" because in blowfish the key is repeated to fill the 72 bytes of expanded key data. bcrypt version `$2a$` fixed this by including the trailing NULL character as a delimiter between repeats.